### PR TITLE
Fix notification mode to match user preference (none, email or PM).

### DIFF
--- a/files/inc/plugins/automaticsubscriptions.php
+++ b/files/inc/plugins/automaticsubscriptions.php
@@ -265,8 +265,19 @@ function automaticsubscriptions_thread(&$data)
 				continue;
 			}
 		}
-		
-		add_subscribed_thread($tid, $user['subscriptionmethod'], $user['uid']);
+
+		$notification = 0;
+		$subscriptionmethod = $user['subscriptionmethod'];
+		if($subscriptionmethod == 2) # email
+		{
+			$notification = 1;
+		}
+		elseif($subscriptionmethod == 3) # PM
+		{
+			$notification = 2;
+		}
+
+		add_subscribed_thread($tid, $notification, $user['uid']);
 	}
 }
 


### PR DESCRIPTION
The 'enums' in the user table and the threadsubscriptions table don't match.

In the user table, the field subscriptionmethod is stored as
  1=no subscribe, 2=email, 3=pm   (see 'subscriptionmethod' in usercp.php for instance).

In the threadsubscriptions table, the field notification is stored as
  0=none, 1=email, 2=pm, as documented in the function add_subscribed_thread (functions_user.php).

So the conversion is necessary, a simple copy of the value changes its meaning.
